### PR TITLE
Add External Interface

### DIFF
--- a/IRSequencer/IRSequencer/Gui/Sequencer.cs
+++ b/IRSequencer/IRSequencer/Gui/Sequencer.cs
@@ -1886,6 +1886,34 @@ namespace IRSequencer.Gui
                 }
             }
         }
+
+        #region External Interface
+        //External interface to start/stop sequences by number
+        //Number is as shown in main Sequencer window, 1 at the top and counting up as you go down.
+        //Methods are static to make reflection code in the other mod accessing this easier.
+        //Remember that Lists are Zero-indexed so the first item in the list is at position zero
+        public static void SequenceRun(int i) //Starts a sequence running, from start if sequence has the Finished flag set, otherwise from where the sequence was paused.
+        {
+            if(HighLogic.LoadedSceneIsFlight && Sequencer.Instance.sequences.ElementAt(i-1) != null)
+            {
+                Sequencer.Instance.sequences.ElementAt(i-1).Start();
+            }
+        }
+        public static void SequencePause(int i) //Pauses a running sequence.
+        {
+            if (HighLogic.LoadedSceneIsFlight && Sequencer.Instance.sequences.ElementAt(i-1) != null)
+            {
+                Sequencer.Instance.sequences.ElementAt(i-1).Pause();
+            }
+        }
+        public static void SequenceReset(int i) //Stop a sequence and reset it to the beginning.
+        {
+            if (HighLogic.LoadedSceneIsFlight && Sequencer.Instance.sequences.ElementAt(i-1) != null)
+            {
+                Sequencer.Instance.sequences.ElementAt(i-1).Reset();
+            }
+        }
+        #endregion
     }
 
     


### PR DESCRIPTION
Do not merge yet, not fully tested.

I'm asking for feedback on this if this approach would work for you to add to IR-Sequencer.

This adds an external interface for other mods to start/stop sequences. I was asked for the functionality to start/stop sequences via the action group system and this gives me the ability to do so. 

All the controlling logic for the action group system is in my mod, this PR is just exposing methods to start/stop/reset sequences.
